### PR TITLE
feat: migrate unit tests to @angular/build:karma

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -75,7 +75,7 @@
           }
         },
         "test": {
-          "builder": "@angular-devkit/build-angular:karma",
+          "builder": "@angular/build:karma",
           "options": {
             "karmaConfig": "karma.conf.js",
             "polyfills": [

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -21,13 +21,16 @@ if (!process.env.CHROME_BIN) {
 module.exports = function (config) {
   config.set({
     basePath: '',
-    frameworks: ['jasmine', '@angular-devkit/build-angular'],
+    // The @angular/build:karma builder injects its own Angular framework plugin
+    // (assets middleware + polyfills) programmatically and explicitly strips the
+    // legacy '@angular-devkit/build-angular' framework/plugin if present, so the
+    // config only needs to declare jasmine and the standard karma plugins here.
+    frameworks: ['jasmine'],
     plugins: [
       require('karma-jasmine'),
       require('karma-chrome-launcher'),
       require('karma-jasmine-html-reporter'),
       require('karma-coverage'),
-      require('@angular-devkit/build-angular/plugins/karma'),
     ],
     client: {
       jasmine: {},

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
       },
       "devDependencies": {
         "@angular-devkit/build-angular": "^21.0.3",
+        "@angular/build": "^21.2.15",
         "@angular/cli": "~21.2.6",
         "@angular/compiler-cli": "^21.0.5",
         "@types/jasmine": "~5.1.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^21.0.3",
+    "@angular/build": "^21.2.15",
     "@angular/cli": "~21.2.6",
     "@angular/compiler-cli": "^21.0.5",
     "@types/jasmine": "~5.1.0",


### PR DESCRIPTION
Fixes #22

## Summary

Migrates the unit-test path off the legacy webpack-based Karma builder to the esbuild-based application builder. This is **Option 1** (lowest risk): a builder swap only. The Vitest migration is deliberately deferred to a future issue.

The `build` target is unchanged — it still uses `@angular-devkit/build-angular:browser`, so `@angular-devkit/build-angular` remains a dependency. Only the `test` target moves to the new builder.

## Changes

- **`angular.json`**: `test` target builder changed from `@angular-devkit/build-angular:karma` → `@angular/build:karma`.
- **`package.json`**: added `@angular/build` as an explicit devDependency at `^21.2.15`, matching the installed Angular 21 toolchain (the exact version that `@angular-devkit/build-angular@21.2.15` already pins). `package-lock.json` updated accordingly (single-line root-dependency reference; the package was already present transitively).
- **`karma.conf.js`**: removed the `'@angular-devkit/build-angular'` framework and the `require('@angular-devkit/build-angular/plugins/karma')` plugin.

## Why the karma.conf.js changes (investigated, not guessed)

Reading the installed builder source (`node_modules/@angular/build/src/builders/karma/`) shows that `@angular/build:karma`:

- Uses `frameworks: ['jasmine']` in its built-in config — there is **no** `@angular/build` framework or plugin to add.
- In `application_builder.js` it **explicitly filters out** the `@angular-devkit/build-angular` framework and `framework:@angular-devkit/build-angular` plugin from any user karma config (logging a warning that they're incompatible with the application builder), then **injects its own** plugins programmatically (`AngularAssetsMiddleware`, `AngularPolyfillsPlugin`).

So the config only needs `jasmine` plus the standard karma plugins. Polyfills (`zone.js`, `zone.js/testing`) continue to come from the `test` target `options.polyfills` in `angular.json` and are injected by the builder's polyfills plugin.

The headless Puppeteer `CHROME_BIN` resolution block and the `ChromeHeadlessNoSandbox` launcher are preserved unchanged.

## Testing

Run on a no-GUI server using Puppeteer's bundled Chromium.

- `npx ng test --watch=false`
  ```
  Chrome Headless 149.0.0.0 (Linux 0.0.0): Executed 3 of 3 SUCCESS (0.163 secs / 0.147 secs)
  TOTAL: 3 SUCCESS
  ```
  Launches `ChromeHeadlessNoSandbox` and now runs through the esbuild application builder ("Application bundle generation complete").
- `npx ng build` → succeeds (build target unchanged; only a pre-existing component-style budget warning remains).
- `npm audit` → **0 vulnerabilities**.