### PR TITLE
fix: bump zone.js to the Angular 21 range

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@angular/router": "^21.0.5",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
-        "zone.js": "~0.13.0"
+        "zone.js": "~0.15.0"
       },
       "devDependencies": {
         "@angular-devkit/build-angular": "^21.0.3",
@@ -2530,6 +2530,43 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.17.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -15694,13 +15731,10 @@
       }
     },
     "node_modules/zone.js": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.13.3.tgz",
-      "integrity": "sha512-MKPbmZie6fASC/ps4dkmIhaT5eonHkEt6eAy80K42tAm0G2W+AahLJjbfi6X9NPdciOE9GRFTTM8u2IiF6O3ww==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      }
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.15.1.tgz",
+      "integrity": "sha512-XE96n56IQpJM7NAoXswY3XRLcWFW83xe0BiAOeMD7K5k5xecOeul3Qcpx6GqEeeHNkW5DWL5zOyTbEfB4eti8w==",
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@angular/router": "^21.0.5",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
-    "zone.js": "~0.13.0"
+    "zone.js": "~0.15.0"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^21.0.3",


### PR DESCRIPTION
Fixes #23

Bumps the stale `zone.js` pin so it matches what Angular 21 expects.

## Change
- `package.json`: `"zone.js": "~0.13.0"` → `"~0.15.0"` (resolves to **0.15.1**).
- Angular 21's `peerOptional` range is `~0.15.0 || ~0.16.0`. Stayed on the latest `0.15.x` rather than jumping to `0.16.x` since `0.15` already satisfies the peer requirement.
- Regenerated `package-lock.json` against the new pin (minimal diff: zone.js entry + a few `@emnapi/*` optional-peer entries that a non-`--legacy-peer-deps` install now records).

## `--legacy-peer-deps` status
**No longer required.** The stale zone.js pin was the *only* ERESOLVE conflict in the tree. After the bump, a clean `npm install` (no flags) succeeds and a fresh-`node_modules` reinstall from the committed lockfile also succeeds — both with **0 vulnerabilities**.

## Testing
- `npm install` (no `--legacy-peer-deps`): succeeds, 0 vulnerabilities.
- `npx ng build`: succeeds. (Pre-existing, unrelated CSS budget warning on `app.component` remains.)
- `npx ng test --watch=false`: **3/3 SUCCESS** (headless `ChromeHeadlessNoSandbox`).
- `npm audit`: **0 vulnerabilities**.

## Notes
- Scoped strictly to the zone.js bump. A lockfile conflict with #22 (karma builder migration) is expected at merge time and will be rebased by a human.