### PR TITLE
docs: update stale 'master' references to 'main'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,4 +22,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Forced `esbuild` to `0.28.1` to resolve the development-server request vulnerability (GHSA-gv7w-rqvm-qjhr) ([#15](https://github.com/J-MaFf/PersonalWebsite/pull/15)).
 - Resolved the remaining transitive Dependabot alerts (`uuid`, `webpack-dev-server`, and others) via `overrides`, bringing the repo to 0 open alerts and 0 `npm audit` vulnerabilities ([#19](https://github.com/J-MaFf/PersonalWebsite/pull/19)).
 
-[Unreleased]: https://github.com/J-MaFf/PersonalWebsite/commits/master
+[Unreleased]: https://github.com/J-MaFf/PersonalWebsite/commits/main

--- a/STATUS.md
+++ b/STATUS.md
@@ -6,7 +6,7 @@ PersonalWebsite is an Angular 21 single-page application (originally scaffolded 
 
 ## Current State — 2026-06-15
 
-**Health: clean.** `master` builds and tests green, there are no open issues or PRs, and there are 0 open Dependabot alerts / 0 `npm audit` vulnerabilities. The repo installs with a plain `npm install` (no `--legacy-peer-deps` required).
+**Health: clean.** `main` builds and tests green, there are no open issues or PRs, and there are 0 open Dependabot alerts / 0 `npm audit` vulnerabilities. The repo installs with a plain `npm install` (no `--legacy-peer-deps` required).
 
 ### Components
 


### PR DESCRIPTION
Fixes #28

The default branch was renamed from `master` to `main`. This updates the two remaining references to the old branch name.

## Changes
- `CHANGELOG.md` — `[Unreleased]` compare link now points to `/commits/main`
- `STATUS.md` — health line now reads "`main` builds and tests green"