### PR TITLE
fix: correct dependabot.yml package-ecosystem (#32)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
+  - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fixed invalid `dependabot.yml` `package-ecosystem` value from empty string to `"npm"` so Dependabot version updates actually run.
+
 ### Added
 - `STATUS.md` and `CHANGELOG.md` to track project state and history ([#27](https://github.com/J-MaFf/PersonalWebsite/pull/27)).
 


### PR DESCRIPTION
Fixes #32

## What changed
Set `package-ecosystem` in `.github/dependabot.yml` from an empty string `""` to `"npm"`. The empty string is invalid and caused Dependabot version updates to silently do nothing.

## Testing / self-review
- Verified the YAML syntax is valid.
- After merge, Dependabot should begin opening PRs for outdated npm dependencies on the weekly schedule.
- No code logic changed; build and tests are unaffected.