### PR TITLE
feat: add CI workflow for build and test (#31)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+# CI workflow — runs on every push and pull_request to main and 2026-review
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - 2026-review
+  pull_request:
+    branches:
+      - main
+      - 2026-review
+
+jobs:
+  build-and-test:
+    name: Build & Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Test (headless)
+        run: npm test -- --watch=false --browsers=ChromeHeadlessNoSandbox

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added GitHub Actions CI workflow (`.github/workflows/ci.yml`) that runs `ng build` and `ng test --watch=false` on every push and PR targeting `main` or `2026-review`.
 - Replaced the default Angular CLI scaffold template in `app.component.html` with a clean personal website structure: sticky header/nav, hero section, About, Projects grid, Contact, and footer. Styles moved to `app.component.css`; added `currentYear` property to the component; updated specs to cover the new sections.
 - `STATUS.md` and `CHANGELOG.md` to track project state and history ([#27](https://github.com/J-MaFf/PersonalWebsite/pull/27)).
 


### PR DESCRIPTION
Fixes #31

## What changed
Added `.github/workflows/ci.yml` with a `build-and-test` job that runs on every push and pull_request targeting `main` or `2026-review`.

Steps:
1. Checkout
2. Setup Node 22 with npm cache
3. `npm ci`
4. `npm run build`
5. `npm test -- --watch=false --browsers=ChromeHeadlessNoSandbox`

The `ChromeHeadlessNoSandbox` launcher is defined in `karma.conf.js` (uses Puppeteer bundled Chromium with `--no-sandbox`), so tests run cleanly in GitHub-hosted runners without installing Chrome separately.

## Testing / self-review
- Workflow YAML is syntactically valid.
- The `ChromeHeadlessNoSandbox` launcher already works locally (8/8 tests pass from PR #37).
- No production code changed; build and test results are unaffected.