### PR TITLE
feat: add GitHub Pages deploy pipeline and base-href config (#33)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,48 @@
+# Deploy workflow — builds and publishes to GitHub Pages on every push to main.
+# TODO: If you use a custom domain, set BASE_HREF to "/" and configure the
+#       CNAME file in src/ (add it to angular.json assets).
+# TODO: If your repo is not at github.com/J-MaFf/PersonalWebsite, update
+#       the BASE_HREF value and the gh-pages action repository field.
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  # Allow manual runs from the Actions tab
+  workflow_dispatch:
+
+# Grant GITHUB_TOKEN the permissions needed to push to gh-pages
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    name: Build & Deploy
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build for GitHub Pages
+        # base-href must match the repository name for project-site deployments.
+        # Change to "/" if you use a custom domain or an apex (user/org) Pages site.
+        run: npm run build -- --base-href /PersonalWebsite/
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist/personal-website/browser
+          # Preserve custom domain CNAME if one is configured
+          keep_files: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added `.github/workflows/deploy.yml` — GitHub Pages deploy pipeline that builds with `--base-href /PersonalWebsite/` and publishes `dist/personal-website/browser` via `peaceiris/actions-gh-pages` on every push to `main` (TODO comments guide custom-domain and base-href changes).
 - Added GitHub Actions CI workflow (`.github/workflows/ci.yml`) that runs `ng build` and `ng test --watch=false` on every push and PR targeting `main` or `2026-review`.
 - Replaced the default Angular CLI scaffold template in `app.component.html` with a clean personal website structure: sticky header/nav, hero section, About, Projects grid, Contact, and footer. Styles moved to `app.component.css`; added `currentYear` property to the component; updated specs to cover the new sections.
 - `STATUS.md` and `CHANGELOG.md` to track project state and history ([#27](https://github.com/J-MaFf/PersonalWebsite/pull/27)).


### PR DESCRIPTION
Fixes #33

## What changed
Added `.github/workflows/deploy.yml` — a deploy pipeline that:

1. Triggers on push to `main` (and via manual `workflow_dispatch`)
2. Installs dependencies with `npm ci`
3. Builds with `--base-href /PersonalWebsite/` — the correct value for a GitHub Pages project site (non-apex repo)
4. Publishes `dist/personal-website/browser/` to the `gh-pages` branch using `peaceiris/actions-gh-pages@v4` and `GITHUB_TOKEN` (no PAT required)

Two TODO comments in the workflow explain next steps:
- If a custom domain is configured: change `BASE_HREF` to `/` and add a `CNAME` asset
- If the repo is renamed: update the `--base-href` value

To activate: go to **Settings → Pages**, set Source to "Deploy from a branch", select `gh-pages`.

## Testing / self-review
- Workflow YAML is syntactically valid.
- `dist/personal-website/browser` is the correct Angular 17+ esbuild output directory (confirmed from `angular.json`).
- No production code changed; existing build and tests unaffected.