### PR TITLE
docs: replace stale Angular CLI scaffold README (#34)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,105 @@
 # PersonalWebsite
 
-This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 16.1.1.
+A personal portfolio/website built with [Angular](https://angular.dev) (v21).
 
-## Development server
+> **Work in progress.** The homepage structure is in place; personal content (bio, projects, contact) is marked with `<!-- TODO: ... -->` comments and needs to be filled in.
 
-Run `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The application will automatically reload if you change any of the source files.
+---
 
-## Code scaffolding
+## Tech stack
 
-Run `ng generate component component-name` to generate a new component. You can also use `ng generate directive|pipe|service|class|guard|interface|enum|module`.
+| Area | Tool |
+|---|---|
+| Framework | Angular 21 (NgModule, non-standalone) |
+| Build | Angular CLI / esbuild (`@angular-devkit/build-angular`) |
+| Tests | Karma + Jasmine + headless Chromium (via Puppeteer) |
+| CI | GitHub Actions (`.github/workflows/ci.yml`) |
+| Hosting | GitHub Pages (`.github/workflows/deploy.yml`) |
 
-## Build
+---
 
-Run `ng build` to build the project. The build artifacts will be stored in the `dist/` directory.
+## Getting started
 
-## Running unit tests
+### Prerequisites
 
-Run `ng test` to execute the unit tests via [Karma](https://karma-runner.github.io).
+- **Node.js 22.x** and npm 10.x
 
-## Running end-to-end tests
+### Install
 
-Run `ng e2e` to execute the end-to-end tests via a platform of your choice. To use this command, you need to first add a package that implements end-to-end testing capabilities.
+```bash
+npm install
+```
 
-## Further help
+### Develop
 
-To get more help on the Angular CLI use `ng help` or go check out the [Angular CLI Overview and Command Reference](https://angular.io/cli) page.
+```bash
+npm start
+```
+
+Opens `http://localhost:4200/`. The app reloads automatically on file changes.
+
+### Build
+
+```bash
+npm run build
+```
+
+Output is written to `dist/personal-website/`.
+
+For a GitHub Pages build (sets the correct `base-href`):
+
+```bash
+npm run build -- --base-href /PersonalWebsite/
+```
+
+### Test
+
+```bash
+npm test -- --watch=false --browsers=ChromeHeadlessNoSandbox
+```
+
+Chromium is bundled by the `puppeteer` devDependency — no system Chrome required.
+On Linux without a sandbox (e.g. a Docker container or GitHub Actions),
+the `ChromeHeadlessNoSandbox` launcher in `karma.conf.js` adds `--no-sandbox` automatically.
+
+---
+
+## CI / CD
+
+| Workflow | File | Trigger |
+|---|---|---|
+| Build & Test | `.github/workflows/ci.yml` | Push / PR to `main` or `2026-review` |
+| Deploy to GitHub Pages | `.github/workflows/deploy.yml` | Push to `main` |
+
+To activate GitHub Pages: **Settings → Pages → Source → "Deploy from a branch" → `gh-pages`**.
+
+---
+
+## Customising content
+
+All placeholder copy in `src/app/app.component.html` is marked with `<!-- TODO: ... -->` comments.
+Replace them with your real name, bio, projects, and contact links.
+The colour theme lives in CSS custom properties at the top of `src/app/app.component.css`.
+
+---
+
+## Project structure
+
+```
+src/
+  app/
+    app.component.html    # Homepage template (hero, about, projects, contact)
+    app.component.css     # Scoped styles with CSS custom properties
+    app.component.ts      # Root component
+    app.component.spec.ts # Unit tests
+    app.module.ts         # Root NgModule
+    app-routing.module.ts # Router configuration
+  index.html
+  main.ts
+  styles.css              # Global styles
+.github/
+  workflows/
+    ci.yml                # Build + test on every push/PR
+    deploy.yml            # Deploy to GitHub Pages on push to main
+  dependabot.yml          # Weekly npm dependency updates
+```


### PR DESCRIPTION
Fixes #34

## What changed
Rewrote `README.md` from the verbatim Angular CLI 16 scaffold to project-specific documentation.

Sections in the new README:
- **Tech stack** table (Angular 21, esbuild, Karma/Jasmine/Puppeteer, CI, GH Pages)
- **Getting started**: install, develop, build, test — with correct commands including `ChromeHeadlessNoSandbox` for headless runs
- **GitHub Pages build note** (explains `--base-href`)
- **CI / CD** table linking to both workflows and instructions to activate Pages
- **Customising content** — points at the `<!-- TODO: ... -->` comments in the template
- **Project structure** tree

Links updated from `angular.io` (v16-era) to `angular.dev` (current).
`ng e2e` note removed — no e2e runner is configured in this project.

## Testing / self-review
- No code changed; build and tests are unaffected.
- Markdown renders correctly (tables, code fences, links).