### PR TITLE
fix: correct deploy.yml publish_dir (#43)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,6 +43,6 @@ jobs:
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./dist/personal-website/browser
+          publish_dir: ./dist/personal-website
           # Preserve custom domain CNAME if one is configured
           keep_files: false


### PR DESCRIPTION
Fixes #43

## What changed
`.github/workflows/deploy.yml` `publish_dir`: `./dist/personal-website/browser` → `./dist/personal-website`.

This project uses the `@angular-devkit/build-angular:browser` builder (`outputPath: dist/personal-website`), so `npm run build` emits the site at `dist/personal-website/index.html` — there is no `browser/` subdirectory (that path only exists with the newer `@angular/build:application` builder). The old value would have published a non-existent directory to GitHub Pages.

## Testing
Ran `npm install && npm run build` on this branch and confirmed `dist/personal-website/index.html` exists with no `dist/personal-website/browser/`.