### PR TITLE
docs: record jmaff.dev going live

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Brought **https://jmaff.dev** live: enabled GitHub Pages (source `gh-pages`, first-ever enablement — the repo's `has_pages` was false, so the old project URL had never actually served), which auto-adopted the published `CNAME` as the custom domain, and turned on Enforce HTTPS once the certificate provisioned. Updated the repo homepage/description to the new URL ([#69](https://github.com/J-MaFf/PersonalWebsite/issues/69)).
 - Adopted **beads** (`bd`, embedded Dolt) as the task/memory layer beneath GitHub Issues, with the dolt-only `.beads/` convention (JSONL exports and hook shims gitignored; state syncs via `refs/dolt/data`). Added repo-level `CLAUDE.md` (build/test commands, architecture, beads workflow reconciled with git-policies) and `AGENTS.md`, plus a SessionStart `bd prime` hook in `.claude/settings.json` ([#70](https://github.com/J-MaFf/PersonalWebsite/pull/70)).
 
 ### Changed

--- a/STATUS.md
+++ b/STATUS.md
@@ -10,7 +10,7 @@ PersonalWebsite is an Angular 22 single-page application (originally scaffolded 
 
 **`npm audit` reports 0 vulnerabilities.** Migrating off the webpack builder removed the entire `webpack-dev-server` → `http-proxy-middleware` chain; the subsequent Karma → Vitest migration dropped the Karma/Jasmine/Puppeteer stack — which removed the last deprecated transitives (`inflight`, `glob@7`, `rimraf@3`) and shrank the dependency tree to ~453 packages (down from ~970 pre-cleanup). The remaining `piscina` RCE is patched via an `overrides` pin to `^5.2.0`. The `esbuild` and `@babel/core` pins remain load-bearing (their parents pin exact vulnerable versions — `@angular/build`/`compiler-cli` pin `@babel/core` to 7.29.0); the now-dead `webpack-dev-server` and `uuid` pins were dropped.
 
-**Hosting.** The site is served from GitHub Pages (`gh-pages` branch) at the apex custom domain **`https://jmaff.dev/`**. The deploy build uses `--base-href /` and ships `src/CNAME` (`jmaff.dev`, registered in `angular.json` assets) into the published output so the custom domain survives `keep_files: false` on each deploy ([#62](https://github.com/J-MaFf/PersonalWebsite/issues/62)).
+**Hosting.** The site is **live** at the apex custom domain **`https://jmaff.dev/`**, served from GitHub Pages (`gh-pages` branch, custom domain `jmaff.dev`, Enforce HTTPS on). The deploy build uses `--base-href /` and ships `src/CNAME` (`jmaff.dev`, registered in `angular.json` assets) into the published output so the custom domain survives `keep_files: false` on each deploy ([#62](https://github.com/J-MaFf/PersonalWebsite/issues/62)). DNS (4 A + 4 AAAA at Cloudflare, DNS-only) and the Pages enablement/HTTPS settings were applied via the GitHub API ([#69](https://github.com/J-MaFf/PersonalWebsite/issues/69)).
 
 ### Components
 
@@ -44,12 +44,11 @@ PersonalWebsite is an Angular 22 single-page application (originally scaffolded 
 | [#58](https://github.com/J-MaFf/PersonalWebsite/issues/58) | Migrate unit tests from Karma to Vitest (browserless; sheds deprecated transitives) | [#60](https://github.com/J-MaFf/PersonalWebsite/pull/60) |
 | [#61](https://github.com/J-MaFf/PersonalWebsite/issues/61) | Adopt beads (`bd`) for AI task tracking | [#70](https://github.com/J-MaFf/PersonalWebsite/pull/70) |
 | [#62](https://github.com/J-MaFf/PersonalWebsite/issues/62) | Serve site at apex custom domain `jmaff.dev` (CNAME + `--base-href /`) | [#68](https://github.com/J-MaFf/PersonalWebsite/pull/68) |
+| [#69](https://github.com/J-MaFf/PersonalWebsite/issues/69) | DNS + Pages setup to bring jmaff.dev live (Pages enabled + custom domain + HTTPS via API) | — (no PR; settings change) |
 
 ### Open Issues
 
-| Issue | Description |
-|---|---|
-| [#69](https://github.com/J-MaFf/PersonalWebsite/issues/69) | Manual DNS + Pages setup to bring jmaff.dev live |
+None.
 
 ## Natural Next Steps
 


### PR DESCRIPTION
Documentation follow-up to #69 (docs-only change recording completed settings work — no dedicated issue).

Updates STATUS.md and CHANGELOG.md to reflect https://jmaff.dev being live: GitHub Pages enabled (source `gh-pages`), custom domain auto-adopted from the published CNAME, Enforce HTTPS on, repo homepage updated. Marks #69 resolved in the resolved-issues table and clears the open-issues table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)